### PR TITLE
Update SDK version to `v0.2.1-0.20220823112121-47067cda967a`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/brianvoe/gofakeit/v6 v6.17.0
-	github.com/conduitio/conduit-connector-sdk v0.2.1-0.20220812170036-f0ac2714fe94
+	github.com/conduitio/conduit-connector-sdk v0.2.1-0.20220823112121-47067cda967a
 	github.com/doug-martin/goqu/v9 v9.18.0
 	github.com/go-playground/locales v0.14.0
 	github.com/go-playground/universal-translator v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/conduitio/conduit-connector-protocol v0.2.1-0.20220802135043-4b89a6c94401 h1:YXw/DQ8j1RjyqLxoWE5MV1s6V6soWolxnzUpIDg4bEY=
 github.com/conduitio/conduit-connector-protocol v0.2.1-0.20220802135043-4b89a6c94401/go.mod h1:jynMd6Kuc7xUABrvYTUrOBuTYAtoQsZ7T6tAB9xAWOo=
-github.com/conduitio/conduit-connector-sdk v0.2.1-0.20220812170036-f0ac2714fe94 h1:Bo6vDjg/FjzLGqvBUjA49uEfXrZmwi8mwPsu860T2Uk=
-github.com/conduitio/conduit-connector-sdk v0.2.1-0.20220812170036-f0ac2714fe94/go.mod h1:9+76jHp4YiO+1iu5Iaudyh830K73icqGOE6w7bqZaAs=
+github.com/conduitio/conduit-connector-sdk v0.2.1-0.20220823112121-47067cda967a h1:VqjfPhBIBb4cTT5ylyeZ2D8YdyOiG2aNToD2ZH/hYIo=
+github.com/conduitio/conduit-connector-sdk v0.2.1-0.20220823112121-47067cda967a/go.mod h1:9+76jHp4YiO+1iu5Iaudyh830K73icqGOE6w7bqZaAs=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=


### PR DESCRIPTION
### Description

- Update SDK version to `v0.2.1-0.20220823112121-47067cda967a`

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-s3/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
